### PR TITLE
[WIP] Add webui logs monitoring to grafana

### DIFF
--- a/monitoring/telegraf.sls
+++ b/monitoring/telegraf.sls
@@ -6,6 +6,7 @@ telegraf.packages:
     - pkgs:
       - telegraf # to collect metrics
       - iputils # ping for telegraf
+      - logwarn # used by logwarn_openqa
 
 /etc/telegraf/telegraf.conf:
   file.managed:

--- a/monitoring/telegraf/scripts/install_openqa_logwarn.sh
+++ b/monitoring/telegraf/scripts/install_openqa_logwarn.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+curl https://raw.githubusercontent.com/os-autoinst/openqa-logwarn/master/logwarn_openqa > /usr/bin/logwarn_openqa
+chmod a+x /usr/bin/logwarn_openqa

--- a/monitoring/telegraf/telegraf-webui.conf
+++ b/monitoring/telegraf/telegraf-webui.conf
@@ -94,6 +94,11 @@
       CUSTOM_LOG %{COMBINED_LOG_FORMAT} %{NUMBER:response_time_us:int}
     '''
 
+[[inputs.exec]]
+  command = "/usr/bin/logwarn_openqa"
+  data_format = "influx"
+  interval = "2m"
+
 {# sync with monitoring/grafana/webui.services.json - and do not reorder, grafana uses the loop index as id #}
 {% for service in ['sshd','openqa-gru','openqa-webui','openqa-livehandler','openqa-scheduler','openqa-websockets','smb','vsftpd','telegraf','salt-master','salt-minion','rsyncd','postgresql','postfix','cron','apache2'] %}
 [[inputs.procstat]]


### PR DESCRIPTION
We want to monitor webui logs using https://github.com/os-autoinst/openqa-logwarn.
This repo provides a pre-configured call for logwarn that extracts
the relevant data from /var/log/openqa

This PR ensures this script is installed and could be executed, and
provides the configuration lines necessary to be used by telegraf

https://progress.opensuse.org/issues/95293