### PR TITLE
Remove wsl 15sp4 from testing.

### DIFF
--- a/openqa/openqa-trigger-from-ibs.sls
+++ b/openqa/openqa-trigger-from-ibs.sls
@@ -64,7 +64,6 @@ https://gitlab.suse.de/openqa/openqa-trigger-from-ibs-plugin:
 
 
 {{ scriptgen('SUSE:SLE-12-SP5:Update:Products:SLERT') }}
-{{ scriptgen('SUSE:SLE-15-SP4:Update:WSL') }}
 {{ scriptgen('SUSE:SLE-15-SP5:Update:WSL') }}
 {{ scriptgen('SUSE:SLE-15-SP6:Update:WSL') }}
 {{ scriptgen('SUSE:SLFO:Products:SL-Micro:6.1:ToTest') }}


### PR DESCRIPTION
According to WSL developers, WSL for sles 15sp4 is no longer supported.

Additional PR for qac-openqa-yaml: https://gitlab.suse.de/qac/qac-openqa-yaml/-/merge_requests/1786#587d266bb27a4dc3022bbed44dfa19849df3044c

Remove WSL 15sp4 poo: https://progress.opensuse.org/issues/165162